### PR TITLE
support nanoseconds in date literal

### DIFF
--- a/pkg/timeutil/parse.go
+++ b/pkg/timeutil/parse.go
@@ -81,9 +81,14 @@ func Parse(value string) (time.Time, error) {
 			return time.UnixMilli(num), nil
 		case len(value) <= 17:
 			// min: 1973-03-03T09:46:40 (100000000000000 us -> 100000000 s)
-			// max: 5138-11-16T09:46:39 (100000000000000 us -> 100000000 s)
+			// max: 5138-11-16T09:46:39 (99999999999999999 us -> 99999999999 s)
 			num, _ := strconv.ParseInt(value, 10, 64)
 			return time.UnixMicro(num), nil
+		case len(value) <= 20:
+			// min: 1973-03-03T09:46:40 (100000000000000000 ns -> 100000000 s)
+			// max: 5138-11-16T09:46:39 (99999999999999999999 ns -> 99999999999 s)
+			num, _ := strconv.ParseInt(value, 10, 64)
+			return time.Unix(0, num), nil
 		default:
 			return time.Time{}, errors.New("timestamp value out of range")
 		}

--- a/pkg/timeutil/parse_test.go
+++ b/pkg/timeutil/parse_test.go
@@ -50,6 +50,7 @@ func TestParse(t *testing.T) {
 		{"1557097200", time.Date(2019, time.May, 6, 0, 0, 0, 0, tz)},
 		{"1557097200000", time.Date(2019, time.May, 6, 0, 0, 0, 0, tz)},
 		{"1557097200000000", time.Date(2019, time.May, 6, 0, 0, 0, 0, tz)},
+		{"1557097200000000000", time.Date(2019, time.May, 6, 0, 0, 0, 0, tz)},
 	}
 
 	for _, tcase := range tcases {


### PR DESCRIPTION
hi! i find myself working with nanoseconds a lot so it would be handy to parse them with the `{}` syntax 

thanks!